### PR TITLE
Add documentation about configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ Runs on port 4000.
 - `curl 'http://localhost:4000/publish/muminfigurer?mode=term-swefin'`
 
 - `curl 'http://localhost:4000/search?q=o&subtype=muminfigurer&mode=term-swefin' -i`
+
+# Adding wordlists
+See [the docs](/docs/add_newlang.md)

--- a/docs/add_newlang.md
+++ b/docs/add_newlang.md
@@ -25,7 +25,7 @@ All possible fields are described below. Most fields have default values (listed
 
 - `resource`: the name of the resource, must be the same as in Karp.
 - `languages`: the language codes of the resource. Should match the languages as given in Karp and in the frontend. `["sv", "fi"]`
-- `sourcelanguage`: the default source language (as given in Karp and the frontend) `"sv"`
+- `sourcelanguage`: the default source language (as given in the frontend) `"sv"`
 - `targetsort`: the name of the field, as given in Karp, to sort the target language by. `"targetform.sort"`
 - `baseform.search`: the name of the field, as given in Karp, to search for baseforms of the source language.
 - `targetform.search`: the name of the field, as given in Karp, to search for baseforms of the target language.

--- a/docs/add_newlang.md
+++ b/docs/add_newlang.md
@@ -1,0 +1,44 @@
+# Adding a new wordlist
+
+To add a new wordlist (a new language pair), all you have to do is to add
+a configuration for the wordlist. The file to be modified is `conf/settings.json`.
+
+A entry for a wordlist looks like this:
+
+```json
+  "term-swefin": {
+    "resource": "term-swefin",
+    "languages": ["sv", "fi"],
+    "sourcelanguage": "sv",
+    "targetsort": "targetform.sort",
+    "baseform.search": "baseform.searchraw",
+    "targetform.search": "targetform.searchraw",
+    "mode": "term-swefin",
+    "subtypes": "data/fin-subtypes.txt",
+    "css": "http://liljeholmen.sprakochfolkminnen.se/KARPexport_Fi-ordlista_HTML.css"
+  }
+  ```
+
+The name of the entry (`term-swefin`) is the internal name, used for the backend. **TODO** should this match something in the frontend?
+
+All possible fields are described below. Most fields have default values (listed in grey), which will be used if the field is left out from the configuration.
+
+- `resource`: the name of the resource, must be the same as in Karp.
+- `languages`: the language codes of the resource. Should match the languages as given in Karp and in the frontend. `["sv", "fi"]`
+- `sourcelanguage`: the default source language (as given in Karp and the frontend) `"sv"`
+- `targetsort`: the name of the field, as given in Karp, to sort the target language by. `"targetform.sort"`
+- `baseform.search`: the name of the field, as given in Karp, to search for baseforms of the source language.
+- `targetform.search`: the name of the field, as given in Karp, to search for baseforms of the target language.
+- `mode`: the Karp mode in which the wordlist lives `term-swefin`
+- `subtypes`: a file (to be created) where all subtypes that are available in the backend are listed.
+- `css`: an url to a css to use when creating html pages of word lists. `"http://liljeholmen.sprakochfolkminnen.se/KARPexport_Fi-ordlista_HTML.css"`
+- `username`: Karp user name `user`
+- `password`: Karp password `psw`
+- `maxsize`: maximum number of entries to list in the reply of a query `500`
+- `maxsize_export`: maximum number of entries to list when doing an export (for example, when creating html pages) `50000`
+- `overflowsize`: For avoiding getting to big responses from Karp. If
+  the number of entries matching a query exceeds this limit, only ask Karp for
+  the words starting with 'a' (or a given symbol, see below). `1000`
+- `standard_first_letter`: the first letter of the alphabet of the source languge. Used with `overflowsize`. `"a"`
+- `myurl`: the base url of the application `""`
+

--- a/docs/add_newlang.md
+++ b/docs/add_newlang.md
@@ -24,7 +24,7 @@ The name of the entry (`term-swefin`) is the internal name, used for the backend
 All possible fields are described below. Most fields have default values (listed in grey), which will be used if the field is left out from the configuration.
 
 - `resource`: the name of the resource, must be the same as in Karp.
-- `languages`: the language codes of the resource. Should match the languages as given in Karp and in the frontend. `["sv", "fi"]`
+- `languages`: the language codes of the resource. Must match the values given in the frontend. Not used in communication with Karp. One of them must match `sourcelanguage` (see below). `["sv", "fi"]`
 - `sourcelanguage`: the default source language (as given in the frontend) `"sv"`
 - `targetsort`: the name of the field, as given in Karp, to sort the target language by. `"targetform.sort"`
 - `baseform.search`: the name of the field, as given in Karp, to search for baseforms of the source language.

--- a/docs/add_newlang.md
+++ b/docs/add_newlang.md
@@ -19,7 +19,7 @@ A entry for a wordlist looks like this:
   }
   ```
 
-The name of the entry (`term-swefin`) is the internal name, used for the backend. **TODO** should this match something in the frontend?
+The name of the entry (`term-swefin`) is the internal name, used for the backend.
 
 All possible fields are described below. Most fields have default values (listed in grey), which will be used if the field is left out from the configuration.
 
@@ -36,7 +36,7 @@ All possible fields are described below. Most fields have default values (listed
 - `password`: Karp password `psw`
 - `maxsize`: maximum number of entries to list in the reply of a query `500`
 - `maxsize_export`: maximum number of entries to list when doing an export (for example, when creating html pages) `50000`
-- `overflowsize`: For avoiding getting to big responses from Karp. If
+- `overflowsize`: For avoiding getting too big responses from Karp. If
   the number of entries matching a query exceeds this limit, only ask Karp for
   the words starting with 'a' (or a given symbol, see below). `1000`
 - `standard_first_letter`: the first letter of the alphabet of the source languge. Used with `overflowsize`. `"a"`


### PR DESCRIPTION
Lite dokumentation om hur man lägger till en ny ordlista / ett nytt språkpar.

Det finns två anledningar till att jag inte  genast lagt till någon faktisk konfiguration för de nya språken:

1. Jag är inte säker på vad deras fältnamn är i Karp, och innan jag lägger tid på att kolla upp det undrar jag om
2. vi verkligen ska lägga till dem nu. Vi hade jiddisch i konfigen tidigare, men tog bort den för att den inte ska synas. Så vitt jag kan se.
