### PR TITLE
Show subtypes even for unpublish modes

### DIFF
--- a/utils/wordlists.py
+++ b/utils/wordlists.py
@@ -67,7 +67,11 @@ class SubtypeHandler(handlers.BaseHandler):
     def get(self):
         unpublished = self.get_query_argument('unpublished', False)
         mode = self.get_query_argument('mode', settings.get('mode'))
-        subtypes = get_subtypes(mode)
+        try:
+            subtypes = get_subtypes(mode)
+        except errors.ConfigurationError:
+            logging.debug('asked for subtypes of unpublished mode')
+            subtypes = []
         logging.debug(' * Subtypes %s' % subtypes)
         if unpublished in [True, "true", "True"]:
             all_subtypes = get_karp_subtypes(mode)


### PR DESCRIPTION
Om man frågar efter sakområden för ett opublicerat mode får man nu tom lista istället för ett felmeddelande. Om modet finns i Karp, och man valt `unpublished=true` så visas de sakområden som Karp listar.
Tex
```
curl '.../mode=term-swelovari&unpublished=true'
$ {"published": [], "unpublished": ["socialord", "medicin", "skola"]}
```